### PR TITLE
reworking how models are parsed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         args: [--pytest-test-first]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.9
+    rev: v0.5.6
     hooks:
       # Run the linter.
       - id: ruff

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Cubist
 
 [![PyPI Version](https://badge.fury.io/py/cubist.svg)](https://badge.fury.io/py/cubist)
-[![GitHub Build](https://github.com/pjaselin/Cubist/actions/workflows/tests.yml/badge.svg
-)](https://github.com/pjaselin/Cubist/actions)
+[![GitHub Build](https://github.com/pjaselin/Cubist/actions/workflows/tests.yml/badge.svg)](https://github.com/pjaselin/Cubist/actions)
 [![codecov](https://codecov.io/gh/pjaselin/Cubist/graph/badge.svg?token=8FAZDANIP7)](https://codecov.io/gh/pjaselin/Cubist)
 [![License](https://img.shields.io/pypi/l/cubist.svg)](https://pypi.python.org/pypi/cubist)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/cubist.svg)](https://pypi.org/project/cubist)

--- a/README.md
+++ b/README.md
@@ -70,10 +70,15 @@ The following parameters can be passed as arguments to the ```Cubist()``` class 
 
 The following attributes are exposed to understand the Cubist model results:
 
-- feature_importances_ (pd.DataFrame): Table of how training data variables are used in the Cubist model.
+- version_ (str): The Cubist model version.
 - rules_ (pd.DataFrame): Table of the rules built by the Cubist model and the percentage of data for which each rule condition applies.
 - coeff_ (pd.DataFrame): Table of the regression coefficients found by the Cubist model.
+- model_statistics_ (dict): Model statistics (e.g. global mean, extrapolation %, ceiling value, floor value)
+- features_statistics_ (pd.DataFrame): Statistics about dataset features.
+- committee_error_reduction_ (float): Error reduction by using committees.
+- n_committees_used_ (int): Number of committees used by Cubist.
 - variables_ (dict): Information about all the variables passed to the model and those that were actually used.
+- feature_importances_ (pd.DataFrame): Table of how training data variables are used in the Cubist model.
 - feature_names_in_ (list): List of features used to train Cubist.
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Cubist
+
 [![PyPI Version](https://badge.fury.io/py/cubist.svg)](https://badge.fury.io/py/cubist)
 [![GitHub Build](https://github.com/pjaselin/Cubist/actions/workflows/tests.yml/badge.svg
 )](https://github.com/pjaselin/Cubist/actions)
@@ -10,14 +11,17 @@
 A Python package for fitting Quinlan's [Cubist](https://www.rulequest.com/cubist-unix.html) v2.07 regression model. Inspired by and based on the [R wrapper](https://github.com/topepo/Cubist) for Cubist. Designed after and inherits from the [scikit-learn](https://scikit-learn.org/stable/) framework.
 
 ## Installation
+
 ```bash
 pip install --upgrade cubist
 ```
 
 ## Background
+
 Cubist is a regression algorithm develped by John Ross Quinlan for generating rule-based predictive models. This has been available in the R world thanks to the work of Max Kuhn and his colleagues. It is introduced to Python with this package and made scikit-learn compatible for easy use with existing model pipelines. Cross-validation and control over whether Cubist creates a composite model is also enabled here.
 
 ## Advantages
+
 Unlike other ensemble models such as RandomForest and XGBoost, Cubist generates a set of rules, making it easy to understand precisely how the model makes it's predictive decisions. Thus tools such as SHAP and LIME are unnecessary as Cubist doesn't exhibit black box behavior.
 
 Like XGBoost, Cubist can perform boosting by the addition of more models (called committees) that correct for the error of prior models (i.e. the second model created corrects for the prediction error of the first, the third for the error of the second, etc.).
@@ -25,6 +29,7 @@ Like XGBoost, Cubist can perform boosting by the addition of more models (called
 In addition to boosting, the model can perform instance-based (nearest-neighbor) corrections to create composite models, thus combining the advantages of these two methods. Note that with instance-based correction, model accuracy may be improved at the expense of computing time (this extra step takes longer) and some interpretability as the linear regression rules are no longer completely followed. It should also be noted that a composite model might be quite large as the full training dataset must be stored in order to perform instance-based corrections for inferencing. A composite model will be used when `auto=False` with `neighbors` set to an integer between 1 and 9. Cubist can be allowed to decide whether to take advantage of composite models with `auto=True`.
 
 ## Use
+
 ```python
 from sklearn.datasets import fetch_california_housing
 from cubist import Cubist
@@ -36,14 +41,15 @@ model.score(X, y)
 ```
 
 ## Sample Output
-<p align="center">
-    <img src="www/iris_cubist_output.png" alt="[Sample Cubist output for Iris dataset" width="400"/>
-</p>
+
+![Sample Cubist output for Iris dataset](./www/iris_cubist_output.png)
 
 The above image is a sample of the verbose output produced by Cubist. It first reports the total number of _cases_ (rows) and _attributes_ (columns) in the training dataset. Below that it summarizes the model by _committee_ (if used but not in this sample) and _rule_ where each rule is definined by an if..then statement along with metrics for this rule in the training data and the linear regression equation used for each rule. The _if_ section of each rule identifies the training input columns and feature value ranges for which this rule holds true. The _then_ statement shows the linear regressor for this rule. The model performance is then summarized by the average and relative absolute errors as well as with the Pearson correlation coefficient r. Finally, the output reports the usage of training features in the model and rules as well as the time taken to complete training.
 
 ## Model Parameters
+
 The following parameters can be passed as arguments to the ```Cubist()``` class instantiation:
+
 - n_rules (int, default=500): Limit of the number of rules Cubist will build. Recommended value is 500.
 - n_committees (int, default=0): Number of committees to construct. Each committee is a rule based model and beyond the first tries to correct the prediction errors of the prior constructed model. Recommended value is 5.
 - neighbors (int, default=None): Integer between 1 and 9 for how many instances should be used to correct the rule-based prediction. If no value is given, Cubist will build a rule-based model only. If this value is set, Cubist will create a composite model with the given number of neighbors. Regardless of the value set, if auto=True, Cubist may override this input and choose a different number of neighbors. Please assess the model for the selected value for the number of neighbors used.
@@ -57,11 +63,14 @@ The following parameters can be passed as arguments to the ```Cubist()``` class 
 - verbose (int, default=0) Should the Cubist output be printed? 1 if yes, 0 if no.
 
 ## Considerations
+
 - For small datasets, using the `sample` parameter is probably inadvisable because Cubist won't have enough samples to produce a representative model.
 - If you are looking for fast inferencing and can spare accuracy, skip using a composite model by not setting a value for `neighbors`.
 
 ## Model Attributes
+
 The following attributes are exposed to understand the Cubist model results:
+
 - feature_importances_ (pd.DataFrame): Table of how training data variables are used in the Cubist model.
 - rules_ (pd.DataFrame): Table of the rules built by the Cubist model and the percentage of data for which each rule condition applies.
 - coeff_ (pd.DataFrame): Table of the regression coefficients found by the Cubist model.
@@ -69,16 +78,19 @@ The following attributes are exposed to understand the Cubist model results:
 - feature_names_in_ (list): List of features used to train Cubist.
 
 ## Benchmarks
-There are many literature examples demonstrating the power of Cubist and comparing it to Random Forest as well as other bootstrapped/boosted models. Some of these are compiled here: https://www.rulequest.com/cubist-pubs.html. To demonstrate this, some benchmark scripts are provided in the respectively named folder.
+
+There are many literature examples demonstrating the power of Cubist and comparing it to Random Forest as well as other bootstrapped/boosted models. Some of these are compiled here: [Cubist in Use](https://www.rulequest.com/cubist-pubs.html). To demonstrate this, some benchmark scripts are provided in the respectively named folder.
 
 ## Literature for Cubist
-- https://sci2s.ugr.es/keel/pdf/algorithm/congreso/1992-Quinlan-AI.pdf
-- http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.34.6358&rep=rep1&type=pdf
+
+- [Learning with Continuous Classes](https://sci2s.ugr.es/keel/pdf/algorithm/congreso/1992-Quinlan-AI.pdf)
 
 ## Publications Using Cubist
-- https://www.rulequest.com/cubist-pubs.html
-- https://www.linkedin.com/pulse/machine-learning-example-r-using-cubist-kirk-mettler
+
+- [Cubist in Use](https://www.rulequest.com/cubist-pubs.html)
+- [A Machine Learning Example in R using Cubist](https://www.linkedin.com/pulse/machine-learning-example-r-using-cubist-kirk-mettler)
 
 ## To Do
+
 - Add visualization utilities
 - Add benchmark scripts

--- a/cubist/_make_data_string.py
+++ b/cubist/_make_data_string.py
@@ -65,9 +65,9 @@ def _make_data_string(x, y=None, w=None):
 
     # remove leading whitespace from all elements
     # handling pandas 2.2.2 feature change (applymap -> map)
-    if hasattr(x, "map"):
+    if hasattr(x, "map"):  # pragma: no cover
         x = x.map(lambda a: a.lstrip())
-    else:  # pragma: no cover
+    else:
         x = x.applymap(lambda a: a.lstrip())
 
     # replace missing values with ?

--- a/cubist/_make_data_string.py
+++ b/cubist/_make_data_string.py
@@ -67,7 +67,7 @@ def _make_data_string(x, y=None, w=None):
     # handling pandas 2.2.2 feature change (applymap -> map)
     if hasattr(x, "map"):  # pragma: no cover
         x = x.map(lambda a: a.lstrip())
-    else:
+    else:  # pragma: no cover
         x = x.applymap(lambda a: a.lstrip())
 
     # replace missing values with ?

--- a/cubist/_make_names_string.py
+++ b/cubist/_make_names_string.py
@@ -72,16 +72,4 @@ def _escapes(x):
     for i in chars:
         x = [c.replace(i, f"\\{i}") for c in x]
     # apply second escaping
-    return [_re_escape(c) for c in x]
-
-
-_special_chars_map = {i: "\\" + chr(i) for i in b"()[]{}?*+-|:;^$\\.&~#\t\n\r\v\f"}
-
-
-def _re_escape(pattern):  # pragma: no cover
-    """Escape special characters in a string.
-    Sourced from 're' Python package."""
-    if isinstance(pattern, str):
-        return pattern.translate(_special_chars_map)
-    pattern = str(pattern, "latin1")
-    return pattern.translate(_special_chars_map).encode("latin1")
+    return [re.escape(c) for c in x]

--- a/cubist/_make_names_string.py
+++ b/cubist/_make_names_string.py
@@ -78,7 +78,7 @@ def _escapes(x):
 _special_chars_map = {i: "\\" + chr(i) for i in b"()[]{}?*+-|:;^$\\.&~#\t\n\r\v\f"}
 
 
-def _re_escape(pattern):
+def _re_escape(pattern):  # pragma: no cover
     """Escape special characters in a string.
     Sourced from 're' Python package."""
     if isinstance(pattern, str):

--- a/cubist/_parse_model.py
+++ b/cubist/_parse_model.py
@@ -25,12 +25,13 @@ def _parse_model(model: str, x, feature_names: list):
     version = _parser(model.popleft())[0]["id"]
     # get the global model statistics
     model_statistics = {
-        k: v for feat in _parser(model.popleft()) for k, v in feat.items()
-    }  # noqa F841
+        k: v for stat in _parser(model.popleft()) for k, v in stat.items()
+    }
     # get the feature statistics
     feature_statistics = []
     while model[0].startswith("att="):
         feature_statistics.append(_parser(model.popleft()))
+    # feature_statistics = None
     feature_statistics = pd.DataFrame(
         [{k: v for d in feat for k, v in d.items()} for feat in feature_statistics]
     )
@@ -267,6 +268,6 @@ def _make_parsed_dict(x):
 
 
 def _parser(x):
-    x = x.split(" ")
+    x = x.split('" ')
     x = [_make_parsed_dict(c) for c in x]
     return x

--- a/cubist/_parse_model.py
+++ b/cubist/_parse_model.py
@@ -1,4 +1,5 @@
 import re
+import math
 import operator
 from collections import deque
 
@@ -17,7 +18,7 @@ OPERATORS = {
 }
 
 
-def _parse_model(model: str, feature_names: list):
+def _parse_model(model: str, x, feature_names: list):
     # split on newline
     model = deque(model.split("\n"))
 
@@ -124,6 +125,7 @@ def _parse_model(model: str, feature_names: list):
                 "value": [""],
                 "category": [""],
                 "type": [""],
+                "percentile": [1.0],
             }
         )
     else:
@@ -143,18 +145,18 @@ def _parse_model(model: str, feature_names: list):
         rules = rules.dropna(subset=["variable"]).reset_index(drop=True)
 
         # get the percentage of data covered by this rule
-        # nrows = x.shape[0]
-        # for i in range(rules.shape[0]):
-        #     # get the current value threshold and comparison operator
-        #     var_value = rules.loc[i, "value"]
-        #     comp_operator = rules.loc[i, "dir"]
-        #     if var_value is not None:
-        #         if not math.isnan(var_value):
-        #             # convert the data to numeric and remove NaNs
-        #             x_col = pd.to_numeric(x[rules.loc[i, "variable"]]).dropna()
-        #             # evaluate and get the percentage of data
-        #             comp_total = OPERATORS[comp_operator](x_col, var_value).sum()
-        #             rules.loc[i, "percentile"] = comp_total / nrows
+        nrows = x.shape[0]
+        for i in range(rules.shape[0]):
+            # get the current value threshold and comparison operator
+            var_value = rules.loc[i, "value"]
+            comp_operator = rules.loc[i, "dir"]
+            if var_value is not None:
+                if not math.isnan(var_value):
+                    # convert the data to numeric and remove NaNs
+                    x_col = pd.to_numeric(x[rules.loc[i, "variable"]]).dropna()
+                    # evaluate and get the percentage of data
+                    comp_total = OPERATORS[comp_operator](x_col, var_value).sum()
+                    rules.loc[i, "percentile"] = comp_total / nrows
 
     # get the indices of rows in model that contain model coefficients
     is_eqn = [i for i, c in enumerate(model) if c.startswith("coeff=")]

--- a/cubist/_parse_model.py
+++ b/cubist/_parse_model.py
@@ -156,13 +156,12 @@ def _parse_model(model: str, x, feature_names: list):
             # get the current value threshold and comparison operator
             var_value = rules.loc[i, "value"]
             comp_operator = rules.loc[i, "dir"]
-            if var_value is not None:
-                if not math.isnan(var_value):
-                    # convert the data to numeric and remove NaNs
-                    x_col = pd.to_numeric(x[rules.loc[i, "variable"]]).dropna()
-                    # evaluate and get the percentage of data
-                    comp_total = OPERATORS[comp_operator](x_col, var_value).sum()
-                    rules.loc[i, "percentile"] = comp_total / nrows
+            if (var_value is not None) and (not math.isnan(var_value)):
+                # convert the data to numeric and remove NaNs
+                x_col = pd.to_numeric(x[rules.loc[i, "variable"]]).dropna()
+                # evaluate and get the percentage of data
+                comp_total = OPERATORS[comp_operator](x_col, var_value).sum()
+                rules.loc[i, "percentile"] = comp_total / nrows
 
     # get the indices of rows in model that contain model coefficients
     is_eqn = [i for i, c in enumerate(model) if c.startswith("coeff=")]
@@ -262,9 +261,7 @@ def _eqn(x, var_names: list):
 
 def _make_parsed_dict(x):
     x = x.split("=")
-    if len(x) > 1:
-        return {x[0]: x[1].strip('"')}
-    return None
+    return {x[0]: x[1].strip('"')}
 
 
 def _parser(x):

--- a/cubist/_parse_model.py
+++ b/cubist/_parse_model.py
@@ -17,21 +17,6 @@ OPERATORS = {
 }
 
 
-# def _split_to_groups(x, f):
-#     """Function to convert two lists into a dictionary where the keys are
-#     unique values in f and the values are lists of the corresponding values in
-#     x. Analogous to the split function in R."""
-#     if len(x) != len(f):
-#         raise ValueError("lists x and f must be of the same length")
-#     groups = {}
-#     for a, b in zip(x, f):
-#         if b in groups:
-#             groups[b].append(a)
-#         else:
-#             groups[b] = [a]
-#     return groups
-
-
 def _parse_model(model: str, feature_names: list):
     # split on newline
     model = deque(model.split("\n"))

--- a/cubist/_parse_model.py
+++ b/cubist/_parse_model.py
@@ -17,19 +17,19 @@ OPERATORS = {
 }
 
 
-def _split_to_groups(x, f):
-    """Function to convert two lists into a dictionary where the keys are
-    unique values in f and the values are lists of the corresponding values in
-    x. Analogous to the split function in R."""
-    if len(x) != len(f):
-        raise ValueError("lists x and f must be of the same length")
-    groups = {}
-    for a, b in zip(x, f):
-        if b in groups:
-            groups[b].append(a)
-        else:
-            groups[b] = [a]
-    return groups
+# def _split_to_groups(x, f):
+#     """Function to convert two lists into a dictionary where the keys are
+#     unique values in f and the values are lists of the corresponding values in
+#     x. Analogous to the split function in R."""
+#     if len(x) != len(f):
+#         raise ValueError("lists x and f must be of the same length")
+#     groups = {}
+#     for a, b in zip(x, f):
+#         if b in groups:
+#             groups[b].append(a)
+#         else:
+#             groups[b] = [a]
+#     return groups
 
 
 def _parse_model(model: str, feature_names: list):
@@ -232,7 +232,7 @@ def _type3(x):
     return {"var": var, "val": val, "text": txt}
 
 
-def _eqn(x, var_names=None):
+def _eqn(x, var_names: list):
     x = x.replace('"', "")
     starts = [m.start(0) for m in re.finditer("(coeff=)|(att=)", x)]
     tmp = [""] * len(starts)
@@ -248,13 +248,14 @@ def _eqn(x, var_names=None):
     nms = tmp[1::2]
     nms = ["(Intercept)"] + nms
     vals = dict(zip(nms, vals))
-    if var_names:
-        vars2 = [var for var in var_names if var not in nms]
-        vals2 = [np.nan] * len(vars2)
-        vals2 = dict(zip(vars2, vals2))
-        vals = {**vals, **vals2}
-        new_names = ["(Intercept)"] + var_names
-        vals = {nm: vals[nm] for nm in new_names}
+
+    # handle column headers
+    vars2 = [var for var in var_names if var not in nms]
+    vals2 = [np.nan] * len(vars2)
+    vals2 = dict(zip(vars2, vals2))
+    vals = {**vals, **vals2}
+    new_names = ["(Intercept)"] + var_names
+    vals = {nm: vals[nm] for nm in new_names}
     return vals
 
 

--- a/cubist/_parse_model.py
+++ b/cubist/_parse_model.py
@@ -45,14 +45,14 @@ def _parse_model(model: str, feature_names: list):
     while model[0].startswith("att="):
         attribute_statistics.append(model.popleft())
     # get the number of committees
-    committee_meta = model.popleft()
-    i_entries = committee_meta.find("entries")
-    # get the error reduction from using committees
-    if committee_meta.startswith("redn"):
-        error_reduction = float(committee_meta[5:i_entries].strip().strip('"'))  # noqa F841
-    else:
-        error_reduction = None  # noqa F841
-    num_committees = int(committee_meta[i_entries + 8 :].strip('"'))  # noqa F841
+    committee_meta = _parser(model.popleft())
+    error_reduction = None
+    num_committees = None
+    for val in committee_meta:
+        if "redn" in val:
+            error_reduction = float(val["redn"])  # noqa F841
+        if "entries" in val:
+            num_committees = int(val["entries"])  # noqa F841
 
     # clean out empty strings
     model = [m for m in model if m.strip() != ""]

--- a/cubist/_parse_model.py
+++ b/cubist/_parse_model.py
@@ -69,14 +69,14 @@ def _parse_model(model, x):
         if line.startswith("rules"):
             com_idx += 1
             rules_idx = 1  # noqa F841
-            print(_parser(line))
-            num_rules = int(_parser(line)[0]["rules"].strip('"'))  # noqa F841
+            print(_parser2(line))
+            num_rules = int(_parser2(line)["rules"])  # noqa F841
         # rule stats
         if line.startswith("conds"):
             pass
         # parse rule info
         if line.startswith("coeff"):
-            print(_parser(line))
+            print(_parser2(line))
 
     # get model length
     model_len = len(model)
@@ -271,7 +271,7 @@ def _eqn(x, var_names=None):
 def _make_parsed_dict(x):
     x = x.split("=")
     if len(x) > 1:
-        return {x[0]: x[1]}
+        return {x[0]: x[1].strip('"')}
     return None
 
 
@@ -279,3 +279,21 @@ def _parser(x):
     x = x.split(" ")
     x = [_make_parsed_dict(c) for c in x]
     return x
+
+
+def _parse_element(x):
+    # split the element on the equal sign and return without the quotes on the
+    # value of the element
+    label, value = x.split("=")
+    return (label, value.strip('"'))
+
+
+def _parser2(x):
+    """Parses a row of the Cubist model string
+    Takes: redn="0.967" entries="3"
+    and converts to: {"redn": "0.967", "entries": "3"}
+    """
+    # split on the space separating each element in the rule
+    x = x.split(" ")
+    # create dictionary key value pairs for each element in the rule
+    return dict([_parse_element(entry) for entry in x])

--- a/cubist/_quinlan_attributes.py
+++ b/cubist/_quinlan_attributes.py
@@ -1,31 +1,39 @@
 import pandas as pd
-from pandas.api.types import is_string_dtype, is_numeric_dtype, \
-    is_datetime64_any_dtype, is_complex_dtype
+from pandas.api.types import (
+    is_string_dtype,
+    is_numeric_dtype,
+    is_datetime64_any_dtype,
+    is_complex_dtype,
+)
 import numpy as np
 
 
 def _is_all_float_dtype(x: pd.Series):
     """check whether all values are of float dtype"""
-    return all(j == float or np.issubdtype(j, np.floating) for j in [type(i) for i in x.values])
+    return all(
+        j is float or np.issubdtype(j, np.floating) for j in [type(i) for i in x.values]
+    )
 
 
 def _is_all_int_dtype(x: pd.Series):
     """check whether all values are of float dtype"""
-    return all(j == int or np.issubdtype(j, np.integer) for j in [type(i) for i in x.values])
+    return all(
+        j is int or np.issubdtype(j, np.integer) for j in [type(i) for i in x.values]
+    )
 
 
 def _get_data_format(x: pd.Series):
     """
     Function to obtain the data type/formatting information for a Pandas Series.
     Return "continuous." for continuous features, the set of values as a comma
-    separated string for categorical features, and the column itself for 
+    separated string for categorical features, and the column itself for
     datetime features.
 
     Parameters
     ----------
     x : pd.Series
         Pandas Series from which to extract data type.
-    
+
     Returns
     -------
     x : str
@@ -56,7 +64,7 @@ def _quinlan_attributes(df: pd.DataFrame) -> dict:
     ----------
     df : pd.DataFrame
         Pandas DataFrame from which column data attributes are obtained.
-    
+
     Returns
     -------
     x : dict

--- a/cubist/_variable_usage.py
+++ b/cubist/_variable_usage.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-def _get_variable_usage(output, feature_names: list):
+def _get_variable_usage(output: str, feature_names: list):
     output = output.split("\n")
     # get the attribute usage section of the model output
     start_vars = [i for i, c in enumerate(output) if "\tAttribute usage" in c]

--- a/cubist/_variable_usage.py
+++ b/cubist/_variable_usage.py
@@ -1,14 +1,14 @@
 import pandas as pd
 
 
-def _get_variable_usage(output, x):
+def _get_variable_usage(output, feature_names: list):
     output = output.split("\n")
     # get the attribute usage section of the model output
-    start_vars = [i for i, c in enumerate(output) if '\tAttribute usage' in c]
+    start_vars = [i for i, c in enumerate(output) if "\tAttribute usage" in c]
     # if not present raise an error
     if len(start_vars) != 1:
-        raise ValueError("cannot find attribute usage data")
-    output = output[start_vars[0]:(len(output))-2]
+        raise ValueError("Cannot find attribute usage data")
+    output = output[start_vars[0] : (len(output)) - 2]
     output = [c.replace("\t", "") for c in output]
     has_pct = [i for i, c in enumerate(output) if "%" in c]
     if len(has_pct) < 1:
@@ -18,15 +18,15 @@ def _get_variable_usage(output, x):
     values = pd.DataFrame(values, columns=["Conditions", "Model"])
     values["Variable"] = [_get_variable(c) for c in output]
 
-    if values.shape[0] < x.shape[1]:
-        x_names = set(x.columns)
+    if values.shape[0] < len(feature_names):
+        x_names = set(feature_names)
         u_names = set(values["Variable"]) if values is not None else set()
         missing_vars = list(x_names - u_names)
         if missing_vars:
             zero_list = [0] * len(missing_vars)
-            usage2 = pd.DataFrame({"Conditions": zero_list,
-                                   "Model": zero_list,
-                                   "Variable": missing_vars})
+            usage2 = pd.DataFrame(
+                {"Conditions": zero_list, "Model": zero_list, "Variable": missing_vars}
+            )
             values = pd.concat([values, usage2], axis=1)
             values = values.reset_index(drop=True)
     return values
@@ -41,7 +41,7 @@ def _get_values(x):
         return x2
     if sum(has_pct) == 1:
         pct_ind = [i for i, c in enumerate(x2) if "%" in c][0]
-        if x2[1:pct_ind+1].count("") < x2[pct_ind+1:].count(""):
+        if x2[1 : pct_ind + 1].count("") < x2[pct_ind + 1 :].count(""):
             x2 = [c for c in x2 if "%" in c][0]
             x2 = float(x2.replace("%", ""))
             return [x2, 0]

--- a/cubist/cubist.py
+++ b/cubist/cubist.py
@@ -409,7 +409,9 @@ class Cubist(BaseEstimator, RegressorMixin):
         self.data_string_ = zlib.compress(data_string.encode())  # noqa W0201
 
         # parse model contents and store useful information
-        self.rules_, self.coeff_ = _parse_model(self.model_, X)  # noqa W0201
+        self.rules_, self.coeff_ = _parse_model(
+            self.model_, list(self.feature_names_in_)
+        )  # noqa W0201
 
         # get the input data variable usage
         self.feature_importances_ = _get_variable_usage(output, X)  # noqa W0201

--- a/cubist/cubist.py
+++ b/cubist/cubist.py
@@ -409,7 +409,15 @@ class Cubist(BaseEstimator, RegressorMixin):
         self.data_string_ = zlib.compress(data_string.encode())  # noqa W0201, pylint: disable=W0201
 
         # parse model contents and store useful information
-        self.rules_, self.coeff_ = _parse_model(  # noqa W0201, pylint: disable=W0201
+        (
+            self.version_,
+            self.rules_,
+            self.coeff_,
+            self.model_statistics_,
+            self.feature_statistics,
+            self.committee_error_reduction_,
+            self.n_committees_,
+        ) = _parse_model(  # noqa W0201, pylint: disable=W0201
             self.model_, X, list(self.feature_names_in_)
         )
 

--- a/cubist/cubist.py
+++ b/cubist/cubist.py
@@ -431,12 +431,14 @@ class Cubist(BaseEstimator, RegressorMixin):
 
         # store a dictionary containing all the training dataset columns and
         # those that were used by the model
-        if self.rules_ is not None:
-            used_variables = set(self.rules_["variable"]).union(set(not_na_cols))
-            self.variables_ = {  # pylint: disable=W0201
-                "all": list(self.feature_names_in_),
-                "used": list(used_variables),
-            }
+        used_variables = set(self.rules_.variable[self.rules_.variable != ""]).union(
+            set(not_na_cols)
+        )
+        self.variables_ = {  # pylint: disable=W0201
+            "all": list(self.feature_names_in_),
+            "used": list(used_variables),
+        }
+
         return self
 
     def predict(self, X):

--- a/cubist/cubist.py
+++ b/cubist/cubist.py
@@ -420,7 +420,9 @@ class Cubist(BaseEstimator, RegressorMixin):
         ) = _parse_model(self.model_, X, list(self.feature_names_in_))
 
         # get the input data variable usage
-        self.feature_importances_ = _get_variable_usage(output, X)  # noqa W0201, pylint: disable=W0201
+        self.feature_importances_ = _get_variable_usage(
+            output, list(self.feature_names_in_)
+        )  # noqa W0201, pylint: disable=W0201
 
         # get the names of columns that have no nan values
         is_na_col = ~self.coeff_.isna().any()

--- a/cubist/cubist.py
+++ b/cubist/cubist.py
@@ -410,7 +410,7 @@ class Cubist(BaseEstimator, RegressorMixin):
 
         # parse model contents and store useful information
         self.rules_, self.coeff_ = _parse_model(
-            self.model_, list(self.feature_names_in_)
+            self.model_, X, list(self.feature_names_in_)
         )  # noqa W0201
 
         # get the input data variable usage

--- a/cubist/cubist.py
+++ b/cubist/cubist.py
@@ -409,17 +409,15 @@ class Cubist(BaseEstimator, RegressorMixin):
         self.data_string_ = zlib.compress(data_string.encode())  # noqa W0201, pylint: disable=W0201
 
         # parse model contents and store useful information
-        (
+        (  # noqa W0201, pylint: disable=W0201
             self.version_,
             self.rules_,
             self.coeff_,
             self.model_statistics_,
-            self.feature_statistics,
+            self.feature_statistics_,
             self.committee_error_reduction_,
-            self.n_committees_,
-        ) = _parse_model(  # noqa W0201, pylint: disable=W0201
-            self.model_, X, list(self.feature_names_in_)
-        )
+            self.n_committees_used_,
+        ) = _parse_model(self.model_, X, list(self.feature_names_in_))
 
         # get the input data variable usage
         self.feature_importances_ = _get_variable_usage(output, X)  # noqa W0201, pylint: disable=W0201

--- a/cubist/cubist.py
+++ b/cubist/cubist.py
@@ -309,7 +309,7 @@ class Cubist(BaseEstimator, RegressorMixin):
 
         # set the feature names if it hasn't already been done
         if not hasattr(self, "feature_names_in_"):
-            self.feature_names_in_ = [f"var{i}" for i in range(X.shape[1])]  # noqa W0201
+            self.feature_names_in_ = [f"var{i}" for i in range(X.shape[1])]  # noqa W0201, pylint: disable=W0201
 
         # check to see if any of the feature names are empty
         if any(n == "" or pd.isnull(n) for n in self.feature_names_in_):
@@ -321,9 +321,9 @@ class Cubist(BaseEstimator, RegressorMixin):
         # check sample weighting
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)
-            self.is_sample_weighted_ = True  # noqa W0201
+            self.is_sample_weighted_ = True  # noqa W0201, pylint: disable=W0201
         else:
-            self.is_sample_weighted_ = False  # noqa W0201
+            self.is_sample_weighted_ = False  # noqa W0201, pylint: disable=W0201
 
         n_rules = self._check_n_rules()
         n_committees = self._check_n_committees()
@@ -336,9 +336,9 @@ class Cubist(BaseEstimator, RegressorMixin):
         random_state = check_random_state(self.random_state)
 
         # number of input features
-        self.n_features_in_ = X.shape[1]  # noqa W0201
+        self.n_features_in_ = X.shape[1]  # noqa W0201, pylint: disable=W0201
         # number of outputs is 1 (single output regression)
-        self.n_outputs_ = 1  # noqa W0201
+        self.n_outputs_ = 1  # noqa W0201, pylint: disable=W0201
 
         # (re)construct a dataframe from X
         X = pd.DataFrame(X, columns=self.feature_names_in_)
@@ -366,7 +366,7 @@ class Cubist(BaseEstimator, RegressorMixin):
         )
 
         # convert output from raw to strings
-        self.model_ = model.decode()
+        self.model_ = model.decode()  # pylint: disable=W0201
         output = output.decode()
 
         # raise Cubist training errors
@@ -391,9 +391,9 @@ class Cubist(BaseEstimator, RegressorMixin):
         # replace "__Sample" with "sample" if this is used in the model
         if "\n_Sample" in names_string:
             output = output.replace("_Sample", "sample")
-            self.model_ = self.model_.replace("_Sample", "sample")
+            self.model_ = self.model_.replace("_Sample", "sample")  # pylint: disable=W0201
             # clean model string when using reserved sample name
-            self.model_ = (
+            self.model_ = (  # pylint: disable=W0201
                 self.model_[: self.model_.index("sample")]
                 + self.model_[self.model_.index("entries") :]
             )
@@ -405,16 +405,16 @@ class Cubist(BaseEstimator, RegressorMixin):
             data_string = "1"
 
         # compress and save descriptors/data
-        self.names_string_ = zlib.compress(names_string.encode())  # noqa W0201
-        self.data_string_ = zlib.compress(data_string.encode())  # noqa W0201
+        self.names_string_ = zlib.compress(names_string.encode())  # noqa W0201, pylint: disable=W0201
+        self.data_string_ = zlib.compress(data_string.encode())  # noqa W0201, pylint: disable=W0201
 
         # parse model contents and store useful information
-        self.rules_, self.coeff_ = _parse_model(
+        self.rules_, self.coeff_ = _parse_model(  # noqa W0201, pylint: disable=W0201
             self.model_, X, list(self.feature_names_in_)
-        )  # noqa W0201
+        )
 
         # get the input data variable usage
-        self.feature_importances_ = _get_variable_usage(output, X)  # noqa W0201
+        self.feature_importances_ = _get_variable_usage(output, X)  # noqa W0201, pylint: disable=W0201
 
         # get the names of columns that have no nan values
         is_na_col = ~self.coeff_.isna().any()
@@ -427,7 +427,7 @@ class Cubist(BaseEstimator, RegressorMixin):
         # those that were used by the model
         if self.rules_ is not None:
             used_variables = set(self.rules_["variable"]).union(set(not_na_cols))
-            self.variables_ = {
+            self.variables_ = {  # pylint: disable=W0201
                 "all": list(self.feature_names_in_),
                 "used": list(used_variables),
             }

--- a/cubist/src/implicitatt.c
+++ b/cubist/src/implicitatt.c
@@ -654,7 +654,7 @@ void DefSemanticsError(int Fi, String Msg, int OpCode)
       sprintf(Op, "%s", "%");
       break;
     case OP_POW:
-      snprintf(Op, "%s", "^");
+      sprintf(Op, "%s", "^");
       break;
     case OP_SIN:
       sprintf(Op, "%s", "sin");

--- a/cubist/src/implicitatt.c
+++ b/cubist/src/implicitatt.c
@@ -672,7 +672,7 @@ void DefSemanticsError(int Fi, String Msg, int OpCode)
       sprintf(Op, "%s", "exp");
       break;
     case OP_INT:
-      snprintf(Op, "%s", "int");
+      sprintf(Op, "%s", "int");
     }
 
     sprintf(XMsg, "%s with '%s'", Msg, Op);

--- a/cubist/tests/test_datasets.py
+++ b/cubist/tests/test_datasets.py
@@ -46,6 +46,17 @@ def test_sklearn_sparse_uncorrelated():
     check_is_fitted(model)
 
 
+def test_one_model_one_committee():
+    # n = 20
+    X, y = fetch_california_housing(return_X_y=True, as_frame=True)
+    model = Cubist(n_rules=2, n_committees=3, verbose=1)
+    model.fit(X, y)
+    check_is_fitted(model)
+    assert model.rules_ is not None
+    print(model.rules_)
+    print(model.coeff_)
+
+
 # def test_openml_titanic():
 #     X, y = fetch_openml(
 #         "titanic", version=2, as_frame=True, return_X_y=True, parser="auto"

--- a/cubist/tests/test_datasets.py
+++ b/cubist/tests/test_datasets.py
@@ -33,7 +33,7 @@ def test_sklearn_california_housing():
 
 
 def test_sklearn_regression():
-    X, y = make_regression(random_state=0)
+    X, y, _ = make_regression(random_state=0)
     model = Cubist()
     model.fit(X, y)
     check_is_fitted(model)

--- a/cubist/tests/test_datasets.py
+++ b/cubist/tests/test_datasets.py
@@ -9,7 +9,6 @@ from sklearn.datasets import (
     fetch_california_housing,
     make_regression,
     make_sparse_uncorrelated,
-    # fetch_openml,
 )
 from sklearn.utils.validation import check_is_fitted
 
@@ -17,6 +16,7 @@ from ..cubist import Cubist
 
 
 def test_sklearn_diabetes_nan():
+    """test diabetes dataset"""
     X, y = load_diabetes(return_X_y=True, as_frame=True)
     # randomly dropping cells with 20% probability
     X = X.mask(np.random.random(X.shape) < 0.2)
@@ -26,6 +26,7 @@ def test_sklearn_diabetes_nan():
 
 
 def test_sklearn_california_housing():
+    """test california housing"""
     X, y = fetch_california_housing(return_X_y=True, as_frame=True)
     model = Cubist()
     model.fit(X, y)
@@ -33,13 +34,15 @@ def test_sklearn_california_housing():
 
 
 def test_sklearn_regression():
-    X, y = make_regression(random_state=0)
+    """test simple regression"""
+    X, y = make_regression(random_state=0)  # pylint: disable=W0632
     model = Cubist()
     model.fit(X, y)
     check_is_fitted(model)
 
 
 def test_sklearn_sparse_uncorrelated():
+    """test sparse uncorrelated"""
     X, y = make_sparse_uncorrelated(random_state=0)
     model = Cubist()
     model.fit(X, y)
@@ -47,6 +50,7 @@ def test_sklearn_sparse_uncorrelated():
 
 
 def test_one_model_one_committee():
+    """test one model/one committee"""
     X, y = fetch_california_housing(return_X_y=True, as_frame=True)
     model = Cubist(n_rules=1, n_committees=1, verbose=1)
     model.fit(X, y)
@@ -55,16 +59,8 @@ def test_one_model_one_committee():
     assert model.coeff_ is not None
 
 
-# def test_openml_titanic():
-#     X, y = fetch_openml(
-#         "titanic", version=2, as_frame=True, return_X_y=True, parser="auto"
-#     )
-#     model = Cubist()
-#     model.fit(X, y)
-#     check_is_fitted(model)
-
-
 def test_small_ds_warning():
+    """test small dataset"""
     with pytest.warns(Warning):
         X = pd.DataFrame(
             dict(

--- a/cubist/tests/test_datasets.py
+++ b/cubist/tests/test_datasets.py
@@ -33,7 +33,7 @@ def test_sklearn_california_housing():
 
 
 def test_sklearn_regression():
-    X, y, _ = make_regression(random_state=0)
+    X, y = make_regression(random_state=0)
     model = Cubist()
     model.fit(X, y)
     check_is_fitted(model)

--- a/cubist/tests/test_datasets.py
+++ b/cubist/tests/test_datasets.py
@@ -52,7 +52,7 @@ def test_sklearn_sparse_uncorrelated():
 def test_one_model_one_committee():
     """test one model/one committee"""
     X, y = fetch_california_housing(return_X_y=True, as_frame=True)
-    model = Cubist(n_rules=1, n_committees=1, verbose=1)
+    model = Cubist(n_rules=1, n_committees=1)
     model.fit(X, y)
     check_is_fitted(model)
     assert model.rules_ is not None

--- a/cubist/tests/test_datasets.py
+++ b/cubist/tests/test_datasets.py
@@ -47,14 +47,12 @@ def test_sklearn_sparse_uncorrelated():
 
 
 def test_one_model_one_committee():
-    # n = 20
     X, y = fetch_california_housing(return_X_y=True, as_frame=True)
-    model = Cubist(n_rules=2, n_committees=3, verbose=1)
+    model = Cubist(n_rules=1, n_committees=1, verbose=1)
     model.fit(X, y)
     check_is_fitted(model)
     assert model.rules_ is not None
-    print(model.rules_)
-    print(model.coeff_)
+    assert model.coeff_ is not None
 
 
 # def test_openml_titanic():

--- a/cubist/tests/test_quinlan_attributes.py
+++ b/cubist/tests/test_quinlan_attributes.py
@@ -82,4 +82,4 @@ def test_get_data_format(test_input, expected, raises):
 )
 def test_quinlan_attributes(test_input, expected, raises):
     with raises:
-        assert type(_quinlan_attributes(test_input)) == expected
+        assert type(_quinlan_attributes(test_input)) is expected

--- a/cubist/tests/test_variable_usage.py
+++ b/cubist/tests/test_variable_usage.py
@@ -1,0 +1,8 @@
+import pytest
+
+from .._variable_usage import _get_variable_usage
+
+
+def test_variable_usage():
+    with pytest.raises(ValueError):
+        _get_variable_usage("", ["A"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cubist"
-version = "0.1.5"
+version = "0.2.0"
 authors = [
   {name = "John Ross Quinlan"},
   {name = "Max Kuhn"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Repository = "https://github.com/pjaselin/Cubist.git"
 Issues = "https://github.com/pjaselin/Cubist/issues"
 
 [tool.setuptools]
-packages = ["cubist"]
+packages = ["cubist", "cubist.src"]
 
 [tool.pytest.ini_options]
 addopts="-v -s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cubist"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
   {name = "John Ross Quinlan"},
   {name = "Max Kuhn"},


### PR DESCRIPTION
Close: #148 

This PR cleans up some linting checks on Python and README as well as updates the pre-commit config. Model metadata is parsed out and ready to be made available in the future. Where Cubist only generates one model, the .rules_ attribute now returns a Pandas Dataframe with one row for that condition indicating 100% coverage. More attributes are enabled with model information.